### PR TITLE
BACKLOG-22554: Set jahia parent to 8.2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.0</version>
     </parent>
     <artifactId>digitall</artifactId>
     <name>Digitall Demo</name>


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-22554